### PR TITLE
Use the content type id for the generated name

### DIFF
--- a/Contentful.ModelsCreator.Cli/Contentful.ModelsCreator.Cli.csproj
+++ b/Contentful.ModelsCreator.Cli/Contentful.ModelsCreator.Cli.csproj
@@ -6,15 +6,15 @@
     <PackAsTool>true</PackAsTool>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>Latest</LangVersion>
-    <Version>0.10.0</Version>
+    <Version>0.11.0</Version>
     <Company>Contentful GmbH</Company>
     <Authors>Contentful</Authors>
     <PackageId>contentful.modelscreator.cli</PackageId>
     <PackageTags>contentful;CMS;cli</PackageTags>
     <Copyright>Contentful GmbH.</Copyright>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <AssemblyVersion>0.10.0.0</AssemblyVersion>
-    <FileVersion>0.10.0.0</FileVersion>
+    <AssemblyVersion>0.11.0.0</AssemblyVersion>
+    <FileVersion>0.11.0.0</FileVersion>
     <RepositoryUrl>https://github.com/tmw-center/dotnet-models-creator-cli</RepositoryUrl>
   </PropertyGroup>
 

--- a/Contentful.ModelsCreator.Cli/ModelsCreator.cs
+++ b/Contentful.ModelsCreator.Cli/ModelsCreator.cs
@@ -103,7 +103,7 @@ using Contentful.Core.Models;
 
             foreach (var contentType in _contentTypes)
             {
-                var safeFileName = GetSafeFilename(contentType.Name);
+                var safeFileName = GetSafeFilename(contentType.SystemProperties.Id);
 
                 var file = new FileInfo($"{dir.FullName}{System.IO.Path.DirectorySeparatorChar}{safeFileName}.cs");
                 if (file.Exists && !Force)
@@ -127,7 +127,7 @@ using Contentful.Core.Models;
                     //start namespace
                     sb.AppendLine("{");
 
-                    sb.AppendLine($"    public class {FormatClassName(contentType.Name)}");
+                    sb.AppendLine($"    public class {FormatClassName(contentType.SystemProperties.Id)}");
                     //start class
                     sb.AppendLine("    {");
 
@@ -243,7 +243,7 @@ using Contentful.Core.Models;
                 return "object";
             }
 
-            return FormatClassName(contentType.Name);
+            return FormatClassName(contentType.SystemProperties.Id);
         }
 
         private string GetDataTypeForListField(Field field)

--- a/Contentful.ModelsCreator.Cli/ModelsCreator.cs
+++ b/Contentful.ModelsCreator.Cli/ModelsCreator.cs
@@ -39,7 +39,7 @@ namespace Contentful.ModelsCreator.Cli
         [Option(CommandOptionType.SingleValue, Description = "Path to the file or directory to create files in")]
         public string Path { get; }
 
-        [VersionOption("0.10.0")]
+        [VersionOption("0.11.0")]
         public bool Version { get; }
 
         private string _templateStart = @"// THIS FILE WAS AUTOMATICALLY GENERATED. DO NOT EDIT.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,19 @@
 # dotnet-models-creator-cli
-A dotnet CLI to automatically create strongly typed c-sharp models. This CLI tool is used internally by the Contentful Visual Studio plugin and the Contentful Visual Studio Code plugin.
-
-## Prerequisites
-The CLI tool uses the "global tools" feature of .NET Core 2.1 and requires the .NET Core 2.1 SDK to be installed. https://www.microsoft.com/net/download/dotnet-core/2.1
-
-## Installation
-Run `dotnet tool install -g contentful.modelscreator.cli` from your command line.
+A dotnet CLI to automatically create strongly typed c-sharp models. This CLI tool should be used to re-generate the wrapping C# classes whenever a content type is added or changed in Contentful.
 
 ## Usage
-Once installed you should now be able to run `contentful.modelscreator.cli --help` to list all the available commands.
+See the [PlatformApi README](https://github.com/tmw-center/platform-api/blob/master/README.md#auto-generated-content-type-classes).
 
-- `-h` to list this help
-- `-v` to show the version of the tool installed
-- `-m` to set the management token to use when communicating with the Contentful API
-- `-s` to set the space id to fetch the content model from
-- `-n` to set the namespace for the classes being created
-- `-e` to specify which environment to fetch the content model for
-- `-f` to force overwrite of any existing files 
-- `-p` to set the path where the class files should be created
+## Building
+Execute `dotnet pack` to build an updated package
 
-### Examples
-Running `contentful.modelscreator.cli -s qz0n5cdakyl9 -m df2a18b8a5b4426741408fc95fa4331c7388d502318c44a5b22b167c3c1b1d03` will create a number of classes in the current working directory based on the content model of the Contentful Example App space.
+## Testing Locally
+After building, you can test your updated tool locally by running:
 
-If you want to specify the namespace of the created classes use the `-n` switch: `contentful.modelscreator.cli -s qz0n5cdakyl9 -m df2a18b8a5b4426741408fc95fa4331c7388d502318c44a5b22b167c3c1b1d03 -n MyProject.Models` 
+```sh
+$: dotnet tool uninstall -g contentful.modelscreator.cli
+$: dotnet tool install --global --add-source <path to repo>/Contentful.ModelsCreator.Cli/bin/Debug --no-cache contentful.modelscreator.cli
+```
 
-If you want to specify the path to create the assets in use the `-p` switch: `contentful.modelscreator.cli -s qz0n5cdakyl9 -m df2a18b8a5b4426741408fc95fa4331c7388d502318c44a5b22b167c3c1b1d03 -n MyProject.Models -p c:\temp`
+## Publishing
+dotnet nuget push "Contentful.ModelsCreator.Cli/bin/Release/contentful.modelscreator.cli.<version>.nupkg" --source "github"


### PR DESCRIPTION
We recently changed the names of some of the content types in Contentful to reflect updated terminology. This caused this tool to spit out a bunch of changed file names, which could break the build. This updates the tool to use the id of the content type for the generated C# names rather than the name of the content type. The ids are less likely to change.

I also updated the README to include installation and publishing instructions.

@demcg, this is something we chatted about briefly.